### PR TITLE
feat(api): add FastAPI IPC server, ServerManager, and health endpoint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,10 @@ repos:
     hooks:
       - id: mypy
         args: [--strict]
-        additional_dependencies: []
+        additional_dependencies:
+          - fastapi>=0.111.0
+          - uvicorn>=0.30.0
+          - httpx>=0.27.0
+          - pydantic>=2.7.0
         pass_filenames: false
         entry: mypy src/cecil/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,12 @@ version = "0.1.0"
 description = "Data Sanitizer & Cost Optimizer — local-first CLI for PII/PHI redaction"
 requires-python = ">=3.11"
 license = {text = "MIT"}
-dependencies = []
+dependencies = [
+    "fastapi>=0.111.0",
+    "uvicorn[standard]>=0.30.0",
+    "httpx>=0.27.0",
+    "pydantic>=2.7.0",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/src/cecil/api/__init__.py
+++ b/src/cecil/api/__init__.py
@@ -1,0 +1,15 @@
+"""Cecil API — FastAPI IPC server and schemas."""
+
+from __future__ import annotations
+
+from cecil.api.schemas import ErrorResponse, HealthResponse
+from cecil.api.server import ServerManager, create_app, wait_for_server
+
+
+__all__ = [
+    "ErrorResponse",
+    "HealthResponse",
+    "ServerManager",
+    "create_app",
+    "wait_for_server",
+]

--- a/src/cecil/api/schemas.py
+++ b/src/cecil/api/schemas.py
@@ -1,0 +1,27 @@
+"""API request and response schemas.
+
+Defines Pydantic v2 models used by FastAPI endpoints for request
+validation and response serialization.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class HealthResponse(BaseModel):
+    """Response from the /health endpoint."""
+
+    status: str = Field(description="Server status indicator")
+    version: str = Field(description="Cecil version string")
+
+
+class ErrorResponse(BaseModel):
+    """Consistent error response format for all API endpoints."""
+
+    error: str = Field(description="Machine-readable error code")
+    message: str = Field(description="Human-readable error description")
+    details: dict[str, str] | None = Field(
+        default=None,
+        description="Additional context about the error",
+    )

--- a/src/cecil/api/server.py
+++ b/src/cecil/api/server.py
@@ -1,0 +1,197 @@
+"""FastAPI IPC server for CLI-to-UI communication.
+
+Provides the local-only FastAPI application, the ServerManager lifecycle
+controller, and the health-check client used by the CLI to verify
+server readiness before launching the browser.
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import socket
+import time
+import types
+
+import httpx
+import uvicorn
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from cecil.api.schemas import ErrorResponse, HealthResponse
+from cecil.utils.errors import ServerStartupError
+
+
+logger = logging.getLogger(__name__)
+
+_CECIL_VERSION = "0.1.0"
+
+
+# ── FastAPI application factory ───────────────────────────────────────
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application.
+
+    Returns:
+        A configured FastAPI instance with CORS middleware and the
+        health endpoint registered.
+    """
+    application = FastAPI(
+        title="Cecil IPC Server",
+        version=_CECIL_VERSION,
+        docs_url=None,
+        redoc_url=None,
+    )
+
+    application.add_middleware(
+        CORSMiddleware,
+        allow_origins=[
+            "http://127.0.0.1",
+            "http://localhost",
+        ],
+        allow_origin_regex=r"^https?://(127\.0\.0\.1|localhost)(:\d+)?$",
+        allow_methods=["GET", "POST", "PUT", "DELETE"],
+        allow_headers=["*"],
+        allow_credentials=False,
+    )
+
+    @application.get(
+        "/api/v1/health",
+        response_model=HealthResponse,
+        responses={500: {"model": ErrorResponse}},
+    )
+    async def health() -> HealthResponse:
+        """Return server health status."""
+        return HealthResponse(status="ok", version=_CECIL_VERSION)
+
+    return application
+
+
+app = create_app()
+
+
+# ── Server lifecycle management ───────────────────────────────────────
+
+
+class ServerManager:
+    """Manages the FastAPI/Uvicorn server lifecycle for CLI-to-UI IPC.
+
+    Handles dynamic port selection, signal-based shutdown, and server
+    readiness verification.  The ``start`` method blocks until the
+    server exits.
+    """
+
+    def __init__(self) -> None:
+        self._port: int | None = None
+        self._server: uvicorn.Server | None = None
+
+    @property
+    def port(self) -> int | None:
+        """The port the server is bound to, or ``None`` if not started."""
+        return self._port
+
+    @staticmethod
+    def find_available_port() -> int:
+        """Find an available TCP port on the loopback interface.
+
+        Binds to port 0 so the OS assigns an ephemeral port, then
+        immediately releases the socket and returns the port number.
+
+        Returns:
+            An available port number.
+        """
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", 0))
+            port: int = sock.getsockname()[1]
+        logger.info("Found available port", extra={"port": port})
+        return port
+
+    def start(self) -> int:
+        """Start the Uvicorn server on an available port.
+
+        This method **blocks** until the server shuts down.  Signal
+        handlers for ``SIGTERM`` and ``SIGINT`` are installed to enable
+        graceful shutdown when the CLI process is killed.
+
+        Returns:
+            The port number the server started on.
+        """
+        self._port = self.find_available_port()
+
+        config = uvicorn.Config(
+            app="cecil.api.server:app",
+            host="127.0.0.1",
+            port=self._port,
+            log_level="warning",
+        )
+        self._server = uvicorn.Server(config)
+
+        signal.signal(signal.SIGTERM, self._handle_shutdown)
+        signal.signal(signal.SIGINT, self._handle_shutdown)
+
+        logger.info(
+            "Starting IPC server",
+            extra={"host": "127.0.0.1", "port": self._port},
+        )
+        self._server.run()
+        return self._port
+
+    def shutdown(self) -> None:
+        """Request a graceful server shutdown.
+
+        Safe to call even when no server is running.
+        """
+        if self._server is not None:
+            logger.info("Shutting down IPC server")
+            self._server.should_exit = True
+
+    def _handle_shutdown(
+        self,
+        signum: int,
+        frame: types.FrameType | None,
+    ) -> None:
+        """Signal handler that triggers graceful server shutdown.
+
+        Args:
+            signum: The signal number received.
+            frame: The current stack frame (unused).
+        """
+        logger.info(
+            "Received shutdown signal",
+            extra={"signal": signal.Signals(signum).name},
+        )
+        self.shutdown()
+
+
+# ── Health-check client ───────────────────────────────────────────────
+
+
+def wait_for_server(port: int, timeout: float = 10.0) -> None:
+    """Poll the health endpoint until the server responds.
+
+    Used by the CLI to verify the IPC server is ready before opening
+    the browser to the mapping UI.
+
+    Args:
+        port: The port the server is expected to be listening on.
+        timeout: Maximum seconds to wait before giving up.
+
+    Raises:
+        ServerStartupError: If the server does not respond within
+            the timeout period.
+    """
+    deadline = time.monotonic() + timeout
+    url = f"http://127.0.0.1:{port}/api/v1/health"
+    logger.info("Waiting for server", extra={"port": port, "timeout": timeout})
+
+    while time.monotonic() < deadline:
+        try:
+            resp = httpx.get(url, timeout=1.0)
+            if resp.status_code == 200:
+                logger.info("Server is ready", extra={"port": port})
+                return
+        except httpx.ConnectError:
+            time.sleep(0.2)
+
+    raise ServerStartupError(f"Server did not start within {timeout}s on port {port}")

--- a/src/cecil/utils/__init__.py
+++ b/src/cecil/utils/__init__.py
@@ -10,6 +10,8 @@ from cecil.utils.errors import (
     ProviderDependencyError,
     ProviderReadError,
     SanitizationError,
+    ServerError,
+    ServerStartupError,
     TelemetryBlockedError,
     TelemetryError,
 )
@@ -23,6 +25,8 @@ __all__ = [
     "ProviderDependencyError",
     "ProviderReadError",
     "SanitizationError",
+    "ServerError",
+    "ServerStartupError",
     "TelemetryBlockedError",
     "TelemetryError",
 ]

--- a/src/cecil/utils/errors.py
+++ b/src/cecil/utils/errors.py
@@ -53,3 +53,14 @@ class TelemetryError(CecilError):
 
 class TelemetryBlockedError(TelemetryError):
     """Telemetry was blocked by policy (e.g., Audit mode or PII detected)."""
+
+
+# ── IPC / Server stage ────────────────────────────────────────────────
+
+
+class ServerError(CecilError):
+    """Errors related to the local IPC server."""
+
+
+class ServerStartupError(ServerError):
+    """The FastAPI/Uvicorn server failed to start or become ready."""

--- a/tests/unit/api/conftest.py
+++ b/tests/unit/api/conftest.py
@@ -1,0 +1,21 @@
+"""Fixtures for API unit tests."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cecil.api.server import create_app
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    """A fresh FastAPI application instance for each test."""
+    return create_app()
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    """A TestClient bound to the test FastAPI app."""
+    return TestClient(app)

--- a/tests/unit/api/test_server.py
+++ b/tests/unit/api/test_server.py
@@ -1,0 +1,259 @@
+"""Unit tests for the FastAPI IPC server, ServerManager, and health endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cecil.api.schemas import ErrorResponse, HealthResponse
+from cecil.api.server import ServerManager, create_app, wait_for_server
+from cecil.utils.errors import CecilError, ServerError, ServerStartupError
+
+
+# ── Health endpoint tests ──────────────────────────────────────────────
+
+
+class TestHealthEndpoint:
+    """Tests for the /api/v1/health endpoint."""
+
+    def test_health_endpoint_returns_200_with_ok_status(self, client: TestClient):
+        resp = client.get("/api/v1/health")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    def test_health_endpoint_returns_version_string(self, client: TestClient):
+        resp = client.get("/api/v1/health")
+        data = resp.json()
+        assert "version" in data
+        assert isinstance(data["version"], str)
+        assert len(data["version"]) > 0
+
+    def test_health_endpoint_response_matches_schema(self, client: TestClient):
+        resp = client.get("/api/v1/health")
+        data = resp.json()
+        assert set(data.keys()) == {"status", "version"}
+        # Validate it parses into the Pydantic model
+        health = HealthResponse(**data)
+        assert health.status == "ok"
+
+
+# ── CORS configuration tests ──────────────────────────────────────────
+
+
+class TestCorsConfiguration:
+    """Tests for CORS middleware configuration."""
+
+    def test_cors_allows_localhost_origin(self, client: TestClient):
+        resp = client.get(
+            "/api/v1/health",
+            headers={"Origin": "http://localhost:3000"},
+        )
+        assert resp.headers.get("access-control-allow-origin") == "http://localhost:3000"
+
+    def test_cors_allows_127_0_0_1_origin(self, client: TestClient):
+        resp = client.get(
+            "/api/v1/health",
+            headers={"Origin": "http://127.0.0.1:5173"},
+        )
+        assert resp.headers.get("access-control-allow-origin") == "http://127.0.0.1:5173"
+
+    def test_cors_allows_localhost_without_port(self, client: TestClient):
+        resp = client.get(
+            "/api/v1/health",
+            headers={"Origin": "http://localhost"},
+        )
+        assert resp.headers.get("access-control-allow-origin") == "http://localhost"
+
+    def test_cors_rejects_external_origin(self, client: TestClient):
+        resp = client.get(
+            "/api/v1/health",
+            headers={"Origin": "http://evil.example.com"},
+        )
+        assert "access-control-allow-origin" not in resp.headers
+
+    def test_cors_preflight_allows_expected_methods(self, client: TestClient):
+        resp = client.options(
+            "/api/v1/health",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        allowed = resp.headers.get("access-control-allow-methods", "")
+        for method in ("GET", "POST", "PUT", "DELETE"):
+            assert method in allowed
+
+    def test_cors_credentials_not_allowed(self, client: TestClient):
+        resp = client.options(
+            "/api/v1/health",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert resp.headers.get("access-control-allow-credentials") != "true"
+
+
+# ── create_app factory tests ──────────────────────────────────────────
+
+
+class TestCreateApp:
+    """Tests for the create_app factory function."""
+
+    def test_create_app_returns_fastapi_instance(self):
+        application = create_app()
+        assert isinstance(application, FastAPI)
+
+    def test_create_app_has_health_route(self):
+        application = create_app()
+        paths = [route.path for route in application.routes]  # type: ignore[union-attr]
+        assert "/api/v1/health" in paths
+
+    def test_create_app_disables_docs(self):
+        application = create_app()
+        assert application.docs_url is None
+        assert application.redoc_url is None
+
+    def test_create_app_produces_independent_instances(self):
+        app1 = create_app()
+        app2 = create_app()
+        assert app1 is not app2
+
+
+# ── ServerManager tests ───────────────────────────────────────────────
+
+
+class TestServerManagerPortSelection:
+    """Tests for ServerManager.find_available_port."""
+
+    def test_find_available_port_returns_positive_integer(self):
+        port = ServerManager.find_available_port()
+        assert isinstance(port, int)
+        assert port > 0
+
+    def test_find_available_port_returns_unprivileged_port(self):
+        port = ServerManager.find_available_port()
+        assert port > 1023
+
+    def test_find_available_port_returns_valid_range(self):
+        port = ServerManager.find_available_port()
+        assert 1024 <= port <= 65535
+
+
+class TestServerManagerInit:
+    """Tests for ServerManager initialization."""
+
+    def test_port_is_none_before_start(self):
+        manager = ServerManager()
+        assert manager.port is None
+
+    def test_shutdown_is_safe_before_start(self):
+        manager = ServerManager()
+        manager.shutdown()  # Should not raise
+
+    def test_shutdown_sets_should_exit_on_server(self):
+        manager = ServerManager()
+        mock_server = MagicMock()
+        manager._server = mock_server
+        manager.shutdown()
+        assert mock_server.should_exit is True
+
+    def test_handle_shutdown_calls_shutdown(self):
+        manager = ServerManager()
+        mock_server = MagicMock()
+        manager._server = mock_server
+        manager._handle_shutdown(15, None)
+        assert mock_server.should_exit is True
+
+
+# ── wait_for_server tests ─────────────────────────────────────────────
+
+
+class TestWaitForServer:
+    """Tests for the wait_for_server health check poller."""
+
+    def test_wait_for_server_raises_on_timeout(self, monkeypatch):
+        def mock_get(*args: object, **kwargs: object) -> None:
+            raise httpx.ConnectError("connection refused")
+
+        monkeypatch.setattr(httpx, "get", mock_get)
+
+        with pytest.raises(ServerStartupError, match="did not start within"):
+            wait_for_server(port=99999, timeout=0.5)
+
+    def test_wait_for_server_succeeds_after_retries(self, monkeypatch):
+        call_count = 0
+
+        def mock_get(*args: object, **kwargs: object) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise httpx.ConnectError("not ready yet")
+            return httpx.Response(
+                200,
+                json={"status": "ok", "version": "0.1.0"},
+            )
+
+        monkeypatch.setattr(httpx, "get", mock_get)
+        wait_for_server(port=12345, timeout=10.0)
+        assert call_count == 3
+
+    def test_wait_for_server_succeeds_immediately_on_200(self, monkeypatch):
+        def mock_get(*args: object, **kwargs: object) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"status": "ok", "version": "0.1.0"},
+            )
+
+        monkeypatch.setattr(httpx, "get", mock_get)
+        wait_for_server(port=12345, timeout=5.0)  # Should not raise
+
+
+# ── Schema tests ──────────────────────────────────────────────────────
+
+
+class TestSchemas:
+    """Tests for Pydantic request/response schemas."""
+
+    def test_health_response_serialization(self):
+        resp = HealthResponse(status="ok", version="0.1.0")
+        data = resp.model_dump()
+        assert data == {"status": "ok", "version": "0.1.0"}
+
+    def test_error_response_with_details(self):
+        resp = ErrorResponse(
+            error="server_error",
+            message="Something went wrong",
+            details={"hint": "check logs"},
+        )
+        data = resp.model_dump()
+        assert data["error"] == "server_error"
+        assert data["details"] == {"hint": "check logs"}
+
+    def test_error_response_details_default_none(self):
+        resp = ErrorResponse(error="not_found", message="Resource not found")
+        assert resp.details is None
+
+
+# ── Error hierarchy tests ─────────────────────────────────────────────
+
+
+class TestServerErrors:
+    """Tests for server-related error classes."""
+
+    def test_server_startup_error_is_cecil_error(self):
+        assert issubclass(ServerStartupError, CecilError)
+
+    def test_server_startup_error_is_server_error(self):
+        assert issubclass(ServerStartupError, ServerError)
+
+    def test_server_error_is_cecil_error(self):
+        assert issubclass(ServerError, CecilError)
+
+    def test_server_startup_error_message_preserved(self):
+        err = ServerStartupError("port 8080 unavailable")
+        assert "port 8080 unavailable" in str(err)


### PR DESCRIPTION
## Summary

- **FastAPI application** with `create_app()` factory — localhost-only IPC server with Swagger/ReDoc disabled, strict CORS via `allow_origin_regex` matching any port on `127.0.0.1`/`localhost` while rejecting all external origins
- **ServerManager** — manages Uvicorn lifecycle with dynamic port selection (OS-assigned ephemeral ports), `SIGTERM`/`SIGINT` signal handlers for graceful shutdown, and a public `shutdown()` method
- **`wait_for_server()`** — health-check poller using httpx that retries `GET /api/v1/health` until the server responds or timeout expires, raising `ServerStartupError` on failure
- **Pydantic v2 schemas** — `HealthResponse` and `ErrorResponse` models in `cecil/api/schemas.py`
- **Error hierarchy** — added `ServerError` and `ServerStartupError` to the stage-specific exception tree
- **Runtime dependencies** — added `fastapi`, `uvicorn[standard]`, `httpx`, and `pydantic` to `pyproject.toml`
- **30 unit tests** — health endpoint, CORS allow/reject, preflight, app factory, port selection, ServerManager init/shutdown, wait_for_server retry/timeout, schema validation, error hierarchy

Closes #4

## Test plan

- [x] `ruff check src/ tests/` — all checks passed
- [x] `ruff format --check src/ tests/` — all 27 files formatted
- [x] `mypy --strict src/cecil/` — no issues in 13 source files
- [x] `pytest tests/ -v` — 58/58 passed (30 new API + 28 existing provider tests)
- [x] Pre-commit hooks (ruff, ruff-format, mypy) pass on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)